### PR TITLE
Open a full screen version of the video

### DIFF
--- a/music_app/post.py
+++ b/music_app/post.py
@@ -1,3 +1,4 @@
+from music_app.utils import convert_url_to_embed_url as cu
 class Post:
     """
     A Class to represent a Post on r/ListenToThis
@@ -12,5 +13,5 @@ class Post:
         self.score = score
         self.thumbnail = thumbnail
         self.timestamp = timestamp
-        self.url = url
+        self.url = cu(url)
     #TODO: Add more getter and setters if required in future

--- a/music_app/settings.py
+++ b/music_app/settings.py
@@ -3,3 +3,4 @@ import os
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DATABASE_NAME = "db.json"
 LOGLEVEL = "DEBUG"
+DOMAIN = "vikings.rmotr.com"

--- a/music_app/templates/base.html
+++ b/music_app/templates/base.html
@@ -14,6 +14,7 @@
 
         <!-- Custom styles -->
         <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='style.css') }}">
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.0.0/jquery.min.js"></script>
     </head>
 
     <body>

--- a/music_app/templates/results.html
+++ b/music_app/templates/results.html
@@ -5,7 +5,10 @@
   <table>
     {% for song in song_list %}
       <tr>
-        <td><a href="{{ song.url }}"><img src="{{ song.thumbnail }}" alt="some_text"/></a></td>
+        <td><a class="video_layer" href="{{ song.url }}"><img src="{{ song.thumbnail }}" alt="some_text"/></a></td>
+	<script>
+		$('.video_layer').colorbox({iframe:true});
+	</script>
         <td>
           <ul>
             <li><strong>{{ song.artist }}</strong></li>

--- a/music_app/utils.py
+++ b/music_app/utils.py
@@ -8,7 +8,7 @@ try:
     import collections.abc as collections
 except ImportError:
     import collections
-from music_app.settings import DATABASE_NAME
+from music_app.settings import DATABASE_NAME, DOMAIN
 from tinydb import TinyDB, Query
 
 def parse_listing(data):
@@ -65,3 +65,12 @@ def get_genres():
 def get_total_songs():
     db = TinyDB(os.path.join(os.getcwd(), DATABASE_NAME))
     return len(db.all())
+
+def convert_url_to_embed_url(url):
+    """
+    Method to convert the url to a video embed url
+    """
+    if 'you' in url:
+        id = url.split('=')[-1]
+        return "https://www.youtube.com/embed/" + id + "?autoplay=1&origin=" + DOMAIN
+    return url


### PR DESCRIPTION
Rather than going to the youtube website, this commit enables
the user to go to a full screen version of the video.
I am not sure if this is the right way of using the jquery script
with a colorbox plugin, but nevertheless, this is what it is.

Right now only works for youtube videos, need to do something similar for the soundcloud links too.

The `convert_url_to_embed_url` method in utils.py takes a url,
and converts the url into a embed url that you get when you use the
embed button on a youtube page. If it's a soundcloud url, the method
does nothing and returns the same url.

This method is then used in the `Post` class, to set the url of the
`Post` object.

Ideally, instead of the full screen video, we would like to have a
behavior where the video pops up and plays on the same page.
